### PR TITLE
Allow evaluation of the first pass

### DIFF
--- a/classes/class.ilExtendedTestStatisticsPageGUI.php
+++ b/classes/class.ilExtendedTestStatisticsPageGUI.php
@@ -297,6 +297,7 @@ class ilExtendedTestStatisticsPageGUI
 		$options = array(
 			ilExteStatSourceData::PASS_SCORED => $this->plugin->txt('pass_scored'),
 			ilExteStatSourceData::PASS_BEST => $this->plugin->txt('pass_best'),
+			ilExteStatSourceData::PASS_FIRST => $this->plugin->txt('pass_first'),
 			ilExteStatSourceData::PASS_LAST => $this->plugin->txt('pass_last'),
 		);
 		$pass_selection->setOptions($options);
@@ -400,6 +401,9 @@ class ilExtendedTestStatisticsPageGUI
 				break;
 			case ilExteStatSourceData::PASS_BEST:
 				$name .= '_best_pass';
+				break;
+			case ilExteStatSourceData::PASS_FIRST:
+				$name .= '_first_pass';
 				break;
 		}
 

--- a/classes/export/class.ilExteStatExport.php
+++ b/classes/export/class.ilExteStatExport.php
@@ -231,6 +231,9 @@ class ilExteStatExport
 			case ilExteStatSourceData::PASS_BEST:
 				$pass = $this->plugin->txt('pass_best');
 				break;
+			case ilExteStatSourceData::PASS_FIRST:
+				$pass = $this->plugin->txt('pass_first');
+				break;
 			case ilExteStatSourceData::PASS_LAST:
 				$pass = $this->plugin->txt('pass_last');
 				break;

--- a/classes/models/class.ilExteStatSourceData.php
+++ b/classes/models/class.ilExteStatSourceData.php
@@ -8,6 +8,7 @@ class ilExteStatSourceData
 {
 	const PASS_LAST = 'last';
 	const PASS_BEST = 'best';
+	const PASS_FIRST = 'first';
 	const PASS_SCORED = 'scored';
 
 	/**
@@ -258,6 +259,7 @@ class ilExteStatSourceData
 			$participant = $this->getParticipant($active_id, true);
 			$participant->best_pass = $userdata->getBestPass();
 			$participant->last_pass = $userdata->getLastPass();
+			$participant->first_pass = 0;
 			$participant->scored_pass = $userdata->getScoredPass();
 
 			switch ($this->pass_selection)
@@ -268,12 +270,14 @@ class ilExteStatSourceData
 				case self::PASS_BEST:
 					$pass = $userdata->getBestPassObject();
 					break;
+				case self::PASS_FIRST:
+					$pass = $userdata->passes[0];
+					break;
 				case self::PASS_SCORED:
 				default:
 					$pass = $userdata->getScoredPassObject();
 					break;
 			}
-
 			if ($pass instanceof ilTestEvaluationPassData)
 			{
 				// all quetions for a participant in the test pass

--- a/classes/models/class.ilExteStatSourceParticipant.php
+++ b/classes/models/class.ilExteStatSourceParticipant.php
@@ -22,6 +22,11 @@ class ilExteStatSourceParticipant
 	public $best_pass;
 
 	/**
+	 * @var integer		index of the first pass
+	 */
+	public $first_pass;
+	
+	/**
 	 * @var integer		index of the scored pass
 	 */
 	public $scored_pass;

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -144,6 +144,7 @@ evaluated_pass#:#Auswertung
 pass_scored#:#Bewerteter Durchlauf (Standard)
 pass_best#:#Bester Durchlauf
 pass_last#:#Letzter Durchlauf
+pass_first#:#Erster Durchlauf
 evaluation_info_id#:#(ID: %s)
 flush_cache#:#Cache aktualisieren
 cache_flushed#:#Der Statistik-Cache dieses Tests wurde aktualisiert. Das geschieht auch automatisch, wenn Testergebnisse geändert oder hinzugefügt wurden.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -144,6 +144,7 @@ evaluated_pass#:#Evaluation
 pass_scored#:#Scored Pass (Standard)
 pass_best#:#Best Pass
 pass_last#:#Last Pass
+pass_first#:#First Pass
 evaluation_info_id#:#(ID: %s)
 flush_cache#:#Update Cache
 cache_flushed#:#The statistics cache of this test is update. This happens automatically when test results are added or changed.


### PR DESCRIPTION
Hi Fred und Jesus,

in diesem Commit kommt eine Option hinzu, um neben dem besten und letzten Durchlauf auch explizit den ersten Durchlauf auszuwerten. Für die teststatistischen Eigenschaften ist das sinnvoll, um Lerneffekte auszublenden.

Bei mir funktioniert es soweit prima und ich hoffe keine Stelle vergessen zu haben.