### PR TITLE
Allow strings with up to 100 chars in options and custom HTML in evaluations

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ https://github.com/ilifau/ExampleEvaluations
 Version History
 ===============
 
+Version 1.1.2 (2018-02-21)
+--------------------------
+- Add selection of first evaluated pass
+- Allow strings in options
+
+
 Version 1.1.1 (2017-09-12)
 --------------------------
 - Permission "Statistics" is checked instead of "Write"

--- a/classes/abstract/class.ilExteEvalBase.php
+++ b/classes/abstract/class.ilExteEvalBase.php
@@ -33,6 +33,11 @@ abstract class ilExteEvalBase
 	protected $provides_chart = false;
 
 	/**
+	 * @var bool    evaluation provides custom HTML
+	 */
+	protected $provides_HTML = false;
+
+	/**
 	 * @var array 	list of allowed test types, e.g. array(self::TEST_TYPE_FIXED)
 	 */
 	protected $allowed_test_types = array();
@@ -246,6 +251,14 @@ abstract class ilExteEvalBase
         return $this->provides_chart;
     }
 
+    /**
+     * @return bool evaluation provides custom HTML
+     */
+    public function providesHTML()
+    {
+    	return $this->provides_HTML;
+    }
+
 	/**
 	 * Get a localized text
 	 * The language variable will be prefixed by self::_getLangPrefix()
@@ -385,5 +398,4 @@ abstract class ilExteEvalBase
 		$chart->setAutoResize(true);
         return $chart;
     }
-
 }

--- a/classes/abstract/class.ilExteEvalBase.php
+++ b/classes/abstract/class.ilExteEvalBase.php
@@ -116,6 +116,9 @@ abstract class ilExteEvalBase
 					case ilExteStatParam::TYPE_BOOLEAN:
 						$param->value = (bool) $data[$param->name];
 						break;
+					case ilExteStatParam::TYPE_STRING:
+						$param->value = (string) $data[$param->name];
+						break;
 				}
 			}
 		}

--- a/classes/abstract/class.ilExteEvalTest.php
+++ b/classes/abstract/class.ilExteEvalTest.php
@@ -90,4 +90,15 @@ abstract class ilExteEvalTest extends ilExteEvalBase
     {
         return $this->generateChart($this->getDetails());
     }
+    
+    /**
+     * Get the custom HTML
+     * @param ilExteStatDetails $a_details
+     * @return string
+     */
+    final public function getCustomHTML()
+    {
+    	$details = $this->getDetails();
+    	return $details->customHTML;
+    }
 }

--- a/classes/class.ilExtendedTestStatisticsConfigGUI.php
+++ b/classes/class.ilExtendedTestStatisticsConfigGUI.php
@@ -117,6 +117,11 @@ class ilExtendedTestStatisticsConfigGUI extends ilPluginConfigGUI
 						$input->setSize(10);
 						$input->setValue($param->value);
 						break;
+					case ilExteStatParam::TYPE_STRING:
+						$input = new ilTextInputGUI($title, $postvar);
+						$input->setMaxLength(100);
+						$input->setValue($param->value);
+						break;
 					case ilExteStatParam::TYPE_INT:
 					default:
 						$input = new ilNumberInputGUI($title, $postvar);

--- a/classes/class.ilExtendedTestStatisticsPageGUI.php
+++ b/classes/class.ilExtendedTestStatisticsPageGUI.php
@@ -187,6 +187,12 @@ class ilExtendedTestStatisticsPageGUI
             $chartHTML = $chart->getHTML();
         }
 
+        $customHTML = '';
+        if ($evaluation->providesHTML())
+        {
+        	$customHTML = $evaluation->getCustomHTML();
+        }
+
 		/** @var  ilExteStatDetailsTableGUI $tableGUI */
 		$this->plugin->includeClass('tables/class.ilExteStatTableGUI.php');
 		$tableGUI = ilExteStatTableGUI::_create('ilExteStatDetailsTableGUI', $this, 'showTestDetails');
@@ -195,7 +201,7 @@ class ilExtendedTestStatisticsPageGUI
 		$tableGUI->setDescription($evaluation->getDescription());
 
 		$legendGUI = ilExteStatTableGUI::_create('ilExteStatLegendTableGUI', $this, 'showTestDetails');
-		$this->tpl->setContent($chartHTML . $tableGUI->getHTML() . $legendGUI->getHTML());
+		$this->tpl->setContent($customHTML . $chartHTML . $tableGUI->getHTML() . $legendGUI->getHTML());
 		$this->tpl->show();
     }
 

--- a/classes/models/class.ilExteStatDetails.php
+++ b/classes/models/class.ilExteStatDetails.php
@@ -41,6 +41,12 @@ class ilExteStatDetails
      */
     public $chartLabelsColumn = 0;
 
+    /**
+     * Custom HTML for the evaluation
+     * @var string
+     */
+    public $customHTML = '';
+    
 	/**
 	 * Get the message for empty details
 	 * @return string

--- a/classes/models/class.ilExteStatParam.php
+++ b/classes/models/class.ilExteStatParam.php
@@ -12,6 +12,7 @@ class ilExteStatParam
 	const TYPE_FLOAT = 'float';
 	const TYPE_INT = 'int';
 	const TYPE_BOOLEAN = 'bool';
+	const TYPE_STRING = 'string';
 
 	/**
 	 * @var string		name of the parameter (should be unique within an evaluation class)

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
 $id = "etstat";
 
 // code version; must be changed for all code changes
-$version = "1.1.1";
+$version = "1.1.2";
 
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -106,3 +106,11 @@ if (!$ilDB->tableExists('etstat_params'))
 		$ilDB->addIndex('etstat_cache', array('tstamp'), 'i1');
     }
 ?>
+<#5>
+<?php
+	//Enlarge storage for params
+    if($ilDB->tableColumnExists('etstat_params', 'value'))
+    {
+    	$ilDB->query('ALTER TABLE etstat_params MODIFY value VARCHAR(100)');
+    }
+?>


### PR DESCRIPTION
Hi Fred und Jesus,

in diesem Commit werden die Konfigurationsmöglichkeiten in der Plugin-Verwaltung erweitert. Für mein Sub-Plugin muss ich eine URL konfigurieren können, die in all dessen Evaluationen genutzt wird.

Daher habe ich "string" als neue Eingabemöglichkeit hinzugefügt und damit eine URL darin Platz findet das Datenbankfeld für den "value" auf 100 Zeichen erweitert.

Um in mehreren Evaluationen auf die gleiche Option zuzugreifen, nutze ich momentan in jeder Klasse
` $plugin = new ilExtendedTestStatisticsPlugin;
   $data = $plugin->getConfig()->getEvaluationParameters("ilExteEvalMyPluginMain");
`
damit ich den Server nicht für jede Evaluation einzeln setzen muss.