### PR TITLE
Fix column index for excel export

### DIFF
--- a/classes/export/class.ilExteStatExport.php
+++ b/classes/export/class.ilExteStatExport.php
@@ -401,14 +401,14 @@ class ilExteStatExport
 
 		$comments = array();
 		$mapping = array();
-		$col = 0;
+		$col = 1;
 		foreach ($header as $name => $def)
 		{
 			if (!empty($def['test_types']) && !in_array($this->statObj->getSourceData()->getTestType(), $def['test_types']))
 			{
 				continue;
 			}
-			$letter = Coordinate::stringFromColumnIndex($col++);
+			$letter = Coordinate::stringFromColumnIndex($col);
 			$mapping[$name] = $letter;
 			$coordinate = $letter.'1';
 			$cell = $worksheet->getCell($coordinate);
@@ -418,6 +418,7 @@ class ilExteStatExport
 			{
 				$comments[$coordinate] = ilExteStatValueExcel::_createComment($def['description']);
 			}
+			$col++;
 		}
 
 		$row = 2;
@@ -478,7 +479,7 @@ class ilExteStatExport
 			return;
 		}
 
-		$col = 0;
+		$col = 1;
 		$comments = array();
 		$mapping = array();
 		foreach ($details->columns as $column)


### PR DESCRIPTION
Coordinate::stringFromColumnIndex (https://github.com/PHPOffice/PhpSpreadsheet/blob/master/src/PhpSpreadsheet/Cell/Coordinate.php#L324) liefert als Spalte Z, wenn der Index 0 ist. Das führt in den Excel-Exporten dazu, dass die planmäßig erste Spalte zu Z verschoben ist und im Fall zahlreicher Spalten ggfs. auch überschrieben wird. 

Beispiel: Im Excel-Sheet "Aggregierte Fragenergebnisse" ist die Spalte "Position" nicht unter A, sondern unter Z.

Da es mich wundert, dass es mir bislang nie aufgefallen ist - bitte selbst nochmal probieren.