### PR TITLE
fix: show offline status in props

### DIFF
--- a/classes/class.ilExtendedTestStatisticsPageGUI.php
+++ b/classes/class.ilExtendedTestStatisticsPageGUI.php
@@ -151,6 +151,12 @@ class ilExtendedTestStatisticsPageGUI
 			return false;
 		}
 
+		if ($this->testObj->getOfflineStatus() == 1) {
+			$properties = array();
+			$properties[] = array('property' => 'Status', 'value' => 'Offline');
+			$this->tpl->setAlertProperties($properties);
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
Hello,

this fixes the missing display of the offline status below the Obj title. Maybe I'm being a little petty, but it drives me crazy when it disappears when you change subtabs.

Since we are still running 54 for exams this fix is also only for 54, but I assume it also works for 7, but is unchecked.

Greetings!