### PR TITLE
writeParameter - line 192 parameter_name has an extra space

### DIFF
--- a/classes/class.ilExtendedTestStatisticsConfig.php
+++ b/classes/class.ilExtendedTestStatisticsConfig.php
@@ -189,7 +189,7 @@ class ilExtendedTestStatisticsConfig
 		global $ilDB;
 		$ilDB->replace('etstat_params',
 			array('evaluation_name' => array('text', $evaluation_name),
-				'parameter_name '=> array('text', $parameter_name)),
+				'parameter_name'=> array('text', $parameter_name)),
 			array('value' => array('text', (string) $value))
 		);
 	}

--- a/plugin.php
+++ b/plugin.php
@@ -5,7 +5,7 @@
 $id = "etstat";
 
 // code version; must be changed for all code changes
-$version = "1.6.0";
+$version = "1.6.1";
 
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin


### PR DESCRIPTION
previously:   'parameter_name ' => array(...
now:             'parameter_name' => array(...

This bug causes a crash when saving configuration settings of the plugin